### PR TITLE
Removed duplicate rules for preferred type literals

### DIFF
--- a/base.js
+++ b/base.js
@@ -80,6 +80,7 @@ module.exports = {
       },
     ],
     "functional/prefer-readonly-type": ["error", { ignorePattern: "^mutable" }],
+    "functional/prefer-type-literal": "off",
     "import/imports-first": "error",
     "import/named": "off",
     "import/namespace": "off",


### PR DESCRIPTION
[`@typescript-eslint/consistent-type-definitions`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-definitions.md) and [`functional/prefer-type-literal`](https://github.com/jonaskello/eslint-plugin-functional/blob/master/docs/rules/prefer-type-literal.md) are rules with similar functionality, so I thought I should remove one or the other.

And I decided to use `@typescript-eslint/consistent-type-definitions`, which has more options and also supports auto fix.