### PR TITLE
Ignore `functional/immutable-data` rule when assigning `module.exports`

### DIFF
--- a/base.js
+++ b/base.js
@@ -1,5 +1,3 @@
-/* eslint-disable functional/immutable-data */
-
 module.exports = {
   extends: [
     "eslint:recommended",
@@ -73,7 +71,7 @@ module.exports = {
     "functional/immutable-data": [
       "error",
       {
-        ignorePattern: ["^mutable"],
+        ignorePattern: ["^mutable", "module.exports"],
         ignoreAccessorPattern: "^*",
         ignoreImmediateMutation: true,
         assumeTypes: true,
@@ -118,5 +116,3 @@ module.exports = {
     "sort-imports": ["error", { ignoreDeclarationSort: true }],
   },
 };
-
-/* eslint-enable functional/immutable-data */

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,8 +1,6 @@
-/* eslint-disable functional/immutable-data */
 module.exports = {
   rules: {
     "type-empty": [1, "never"],
     "subject-empty": [1, "never"],
   },
 };
-/* eslint-enable functional/immutable-data */

--- a/react.js
+++ b/react.js
@@ -1,5 +1,3 @@
-/* eslint-disable functional/immutable-data */
-
 module.exports = {
   extends: [
     require.resolve("./base"),
@@ -28,5 +26,3 @@ module.exports = {
     "react/require-render-return": "off",
   },
 };
-
-/* eslint-enable functional/immutable-data */

--- a/release.config.js
+++ b/release.config.js
@@ -1,4 +1,3 @@
-/* eslint-disable functional/immutable-data */
 module.exports = {
   branches: ["main"],
   plugins: [
@@ -22,4 +21,3 @@ module.exports = {
     ],
   ],
 };
-/* eslint-enable functional/immutable-data */


### PR DESCRIPTION
When writing code that is not an ES module, such as a configuration file, we often assign values to `module.exports`.
So I added an ignore rule because it's hard to ignore every time in this case.

```js
/* eslint-disable functional/immutable-data */ <-- NO MORE THIS COMMENT
module.exports = {
  rules: {
    "type-empty": [1, "never"],
    "subject-empty": [1, "never"],
  },
};
/* eslint-enable functional/immutable-data */ <-- NO MORE THIS COMMENT
```

