### PR TITLE
fix(base.js): disable @typescript-eslint/prefer-readonly-parameter-type

### DIFF
--- a/base.js
+++ b/base.js
@@ -49,6 +49,7 @@ module.exports = {
       },
     ],
     "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/prefer-readonly-parameter-type": "off",
     "@typescript-eslint/prefer-ts-expect-error": "error",
     "arrow-body-style": ["error", "as-needed"],
     "default-case": "error",


### PR DESCRIPTION
Disable [`@typescript-eslint/prefer-readonly-parameter-type`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md)

Reasons:
- The autofix is not available currently and it is difficult to fix immediately.
- Many errors depend on external dependencies.