### PR TITLE
feat(base.js): fix typos for @typescript-eslint/prefer-readonly-parameter-types

### DIFF
--- a/base.js
+++ b/base.js
@@ -49,7 +49,7 @@ module.exports = {
       },
     ],
     "@typescript-eslint/no-var-requires": "off",
-    "@typescript-eslint/prefer-readonly-parameter-type": "off",
+    "@typescript-eslint/prefer-readonly-parameter-types": "off",
     "@typescript-eslint/prefer-ts-expect-error": "error",
     "arrow-body-style": ["error", "as-needed"],
     "default-case": "error",


### PR DESCRIPTION
Fixed a typo in the rule name for `@typescript-eslint/prefer-readonly-parameter-types`