### PR TITLE
feat(react): add rule 'react/jsx-curly-brace-presence'

### DIFF
--- a/react.js
+++ b/react.js
@@ -17,6 +17,10 @@ module.exports = {
     "react/forbid-component-props": ["error", { forbid: ["style"] }],
     "react/forbid-dom-props": ["error", { forbid: ["style"] }],
     "react/jsx-boolean-value": "error",
+    "react/jsx-curly-brace-presence": [
+      "error",
+      { props: "never", children: "never" },
+    ],
     "react/jsx-no-bind": "error",
     "react/jsx-no-useless-fragment": ["error", { allowExpressions: true }],
     "react/no-deprecated": "off",


### PR DESCRIPTION
Add [`react/jsx-curly-brace-presence`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md) rule.

Incorrect example:
```jsx
<>
  <App>{'Hello world'}</App>
  <App prop={'Hello world'} attr={"foo"} />
</>
```

Thiis will fix to:
```jsx
<>
  <App>Hello world</App>
  <App prop="Hello world" attr="foo" />
</>
```