### PR TITLE
:wrench: Disable functional/prefer-immutable-types rule

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -47,6 +47,7 @@ module.exports = {
     "functional/no-this-expressions": "off",
     "functional/no-throw-statements": "off",
     "functional/no-try-statements": "off",
+    "functional/prefer-immutable-types": "off",
     "functional/prefer-property-signatures": "error",
     "functional/prefer-readonly-type": ["error", { ignorePattern: "^mutable" }],
     "functional/prefer-type-literal": "off",


### PR DESCRIPTION
The [`functional/prefer-immutable-types`](https://github.com/eslint-functional/eslint-plugin-functional/blob/main/docs/rules/prefer-immutable-types.md) rule to be disabled because uncontrolled library types may be used.