### PR TITLE
:wrench: Re-enable `import/no-unresolved`

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -60,7 +60,6 @@ module.exports = {
     "import/namespace": "off",
     "import/newline-after-import": "error",
     "import/no-duplicates": "error",
-    "import/no-unresolved": "off",
     "import/order": [
       "error",
       {


### PR DESCRIPTION
Re-enabled the `import/unresolved` rule because `tsc` cannot check some unresolved files (*.png, *.jpg, etc.).